### PR TITLE
Update project.clj to use org.clojure/clojure 1.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/atomisthq/automation-client-clj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/core.async "0.4.474"]
 
                  ;; websocket


### PR DESCRIPTION
Update project.clj to use org.clojure/clojure 1.9.0 [atomist:generated]