### PR TITLE
Fix: adds a 'slack' attribute if missing

### DIFF
--- a/src/com/atomist/automation/core.clj
+++ b/src/com/atomist/automation/core.clj
@@ -187,7 +187,10 @@
         (update :destinations (constantly [(merge
                                             (:source o)
                                             {:user_agent "slack"})]))
-        (update-in [:destinations 0 :slack] #(dissoc % :user)))
+        (update-in [:destinations 0] (fn [destination]
+                                       (if (some? (:slack destination))
+                                         (update destination :slack dissoc :user)
+                                         destination))))
     o))
 
 (defn add-slack-source [command team-id team-name]


### PR DESCRIPTION
We don't always want this, and right now it breaks bot command reponse validation